### PR TITLE
Attach header before yielding to downstream

### DIFF
--- a/koa.js
+++ b/koa.js
@@ -24,7 +24,7 @@ module.exports = function requestId(options) {
 
   return function *requestId(next) {
     this[options.paramName] = this.get(options.reqHeader) || this.query[options.paramName] || options.generator();
-    yield next;
     this.set(options.resHeader, this[options.paramName]);
+    yield* next;
   };
 };

--- a/test/koa.test.js
+++ b/test/koa.test.js
@@ -117,5 +117,25 @@ describe('Koa', function () {
         .get('/')
         .expect('X-Request-Id', gen(), done);
     });
+
+    it('header is populated in case of error', function (done) {
+      var app = koa();
+
+      // the default error handler removes all headers by design,
+      // so we use a custom handler
+      app.use(function *onerror(next) {
+        try {
+          yield* next;
+        } catch(e) {
+          // do nothing
+        }
+      }).use(requestId()).use(function *err() {
+        this.throw();
+      });
+
+      request(app.listen())
+        .get('/')
+        .expect('X-Request-Id', idPattern, done);
+    });
   });
 });


### PR DESCRIPTION
The built-in error handler removes all headers by design
(see https://github.com/koajs/koa/pull/413#issuecomment-74398234 for details),
so in the test a custom error handler is used.

`yield next` changed to `yield* next`, because of reasons:
http://www.jongleberry.com/delegating-yield.html

Fixes #1 
