### PR TITLE
fix #4 reuse request id when present in current request

### DIFF
--- a/express.js
+++ b/express.js
@@ -23,7 +23,7 @@ module.exports = function requestId(options) {
   var options = defaults(options);
 
   return function requestId(req, res, next) {
-    req[options.paramName] = req.get(options.reqHeader) || req.query[options.paramName] || options.generator();
+    req[options.paramName] = req[options.paramName] || req.get(options.reqHeader) || req.query[options.paramName] || options.generator();
     res.setHeader(options.resHeader, req[options.paramName]);
     next();
   };

--- a/koa.js
+++ b/koa.js
@@ -23,7 +23,7 @@ module.exports = function requestId(options) {
   var options = defaults(options);
 
   return function *requestId(next) {
-    this[options.paramName] = this.get(options.reqHeader) || this.query[options.paramName] || options.generator();
+    this[options.paramName] = this[options.paramName] || this.get(options.reqHeader) || this.query[options.paramName] || options.generator();
     this.set(options.resHeader, this[options.paramName]);
     yield* next;
   };

--- a/test/express.test.js
+++ b/test/express.test.js
@@ -61,6 +61,19 @@ describe('Express', function () {
         .get('/?requestId=' + fixture)
         .expect('X-Request-Id', fixture, done);
     });
+
+    it('sets X-Request-Id when present on request', function (done) {
+      var app = express();
+      app.use(function(req, res, next){
+        req.requestId = 'something';
+        next();
+      });
+      app.use(requestId());
+
+      request(app)
+        .get('/')
+        .expect('X-Request-Id', 'something', done);
+    });
   });
 
   describe('requestId({})', function () {
@@ -119,4 +132,3 @@ describe('Express', function () {
     });
   });
 });
-

--- a/test/koa.test.js
+++ b/test/koa.test.js
@@ -61,6 +61,19 @@ describe('Koa', function () {
         .get('/?requestId=' + fixture)
         .expect('X-Request-Id', fixture, done);
     });
+
+    it('sets X-Request-Id when present on request', function (done) {
+      var app = koa();
+      app.use(function *requestId(next) {
+        this.requestId = 'something';
+        yield* next;
+      });
+      app.use(requestId());
+
+      request(app.listen())
+        .get('/')
+        .expect('X-Request-Id', 'something', done);
+    });
   });
 
   describe('requestId({})', function () {


### PR DESCRIPTION
fix #4 and allow reusing a request id present in the request.
