### PR TITLE
Update uuid to version 3.0.0

### DIFF
--- a/defaults.js
+++ b/defaults.js
@@ -4,7 +4,7 @@
  * imports.
  */
 
-var uuid = require('node-uuid').v4;
+var uuid = require('uuid').v4;
 
 /**
  * exports.

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/wilmoore/request-id.js/issues"
   },
   "dependencies": {
-    "node-uuid": "^1.4.1"
+    "uuid": "^3.0.0"
   },
   "devDependencies": {
     "chai": "^1.9.2",

--- a/readme.md
+++ b/readme.md
@@ -66,7 +66,7 @@
     % curl example.com?requestId=a37cacc3-71d5-40f0-a329-a051a3949ced
     //=> X-Request-ID: a37cacc3-71d5-40f0-a329-a051a3949ced
 
-###### Custom Value Generator Function (default: [node-uuid.v4])
+###### Custom Value Generator Function (default: [uuid.v4])
 
     app.use(requestId({
       generator: function () { return 'ABC'; }
@@ -89,7 +89,7 @@
   [MIT](license)
 
 [connect-rid]:            https://www.npmjs.org/package/connect-rid
-[node-uuid.v4]:           https://github.com/broofa/node-uuid#uuidv4options--buffer--offset
+[uuid.v4]:                https://github.com/kelektiv/node-uuid#uuidv4options--buffer--offset
 [koa-request-id]:         https://www.npmjs.org/package/koa-request-id
 [express-request-id]:     https://www.npmjs.org/package/express-request-id
 [connect-request-id]:     https://www.npmjs.org/package/connect-request-id


### PR DESCRIPTION
## Version 3.0.0 of [uuid](https://github.com/kelektiv/node-uuid) just got published.

Hi there,

This week a new version of the [uuid](https://github.com/kelektiv/node-uuid) module got released. The old module which was available by the name [node-uuid](https://www.npmjs.com/package/node-uuid) got deprecated and will show error message upon every install of the module.

To get rid of those install errors I've created this **automated pull request**. I've run some checks against your code base to test whether you're using one of the [deprecated apis](https://github.com/kelektiv/node-uuid/commit/5ae7287fc935eb55ef39133e4be17ef623ca000e), but this isn't the case.


Please test the changes against your code. I didn't run any tests and therefore can't guarantee that it isn't breaking. You can also just close this pr if you don't want to update your module.

In case there's already another pr open to upgrade uuid, I'm sorry for the effort I'm causing.